### PR TITLE
Fixed potential optimisation

### DIFF
--- a/src/quadratix/Combination.java
+++ b/src/quadratix/Combination.java
@@ -16,18 +16,18 @@ import java.util.stream.Collectors;
 public class Combination extends Vector<Long> implements Comparable<Combination>, Serializable, Cloneable {
 	
 	public Combination(@NotNull Long... elements) {
-		super();
+		super(elements.length);
 		this.addAll(Arrays.asList(elements));
 	}
 	public Combination(@NotNull Integer... elements) {
-		super();
+		super(elements.length);
 		this.addAll(Arrays.stream(elements).map(Long::new).collect(Collectors.toList()));
 	}
 	public Combination(int length) {
 		super(length);
 	}
 	public Combination() {
-		super();
+		super(0);
 	}
 	public Combination(@NotNull Collection<? extends Long> collection) {
 		super(collection);


### PR DESCRIPTION
* Fixed potential bug in constructors of `Combination` : `super()` did not have any argument in most of the case, whereas it needs the length for optimisation